### PR TITLE
Rachelcorinneharris rachelcorinneharris/large strain

### DIFF
--- a/src/felib/element/__init__.py
+++ b/src/felib/element/__init__.py
@@ -10,11 +10,16 @@ from .dcnd import DCP3
 from .dcnd import DCP4
 from .cnd import CPE4NL
 from .cnd import CPS4NL
+from .cnd import CPS3NL
+from .cnd import CPE3NL
+from .cnd import CPS8NL
+from .cnd import CPE8NL
 from .isop import IsoparametricElement
 from .reference import Quad4
 from .reference import Quad8
 from .reference import ReferenceElement
 from .reference import Tri3
+
 
 __all__ = [
     "Element",
@@ -27,6 +32,10 @@ __all__ = [
     "CPS3",
     "CPS4",
     "CPS4NL",
+    "CPS3NL",
+    "CPE3NL",
+    "CPE8NL",
+    "CPS8NL",
     "CPS8",
     "DCP3",
     "DCP4",

--- a/src/felib/element/__init__.py
+++ b/src/felib/element/__init__.py
@@ -8,6 +8,8 @@ from .cnd import CPS4
 from .cnd import CPS8
 from .dcnd import DCP3
 from .dcnd import DCP4
+from .cnd import CPE4NL
+from .cnd import CPS4NL
 from .isop import IsoparametricElement
 from .reference import Quad4
 from .reference import Quad8
@@ -19,10 +21,12 @@ __all__ = [
     "IsoparametricElement",
     "CPE3",
     "CPE4",
+    "CPE4NL",
     "CPE4H",
     "CPE8",
     "CPS3",
     "CPS4",
+    "CPS4NL",
     "CPS8",
     "DCP3",
     "DCP4",

--- a/src/felib/element/cnd.py
+++ b/src/felib/element/cnd.py
@@ -269,6 +269,8 @@ class CPS4(CPX4):
         B[2, 1::2] = dNdx[0]
         return B
 
+class CPS4NL(CPS4):
+    nlgeom = True
 
 class CPE4(CPX4):
     """Plane strain constant strain quadrilateral element."""
@@ -285,6 +287,8 @@ class CPE4(CPX4):
         B[3, 1::2] = dNdx[0]
         return B
 
+class CPE4NL(CPE4):
+    nlgeom = True
 
 class CPE4H(CPE4):
     """Plane strain quadrilateral with hybrid u-p fomulation, constant pressure."""

--- a/src/felib/element/cnd.py
+++ b/src/felib/element/cnd.py
@@ -272,6 +272,33 @@ class CPS4(CPX4):
 class CPS4NL(CPS4):
     nlgeom = True
 
+    def update_state(
+        self,
+        material: Material,
+        step: int,
+        increment: int,
+        time: Sequence[float],
+        dt: float,
+        eleno: int,
+        p: NDArray,
+        u: NDArray,
+        e: NDArray,
+        de: NDArray,
+        hsv: NDArray,
+    ) -> tuple[NDArray, NDArray]:
+        temp = dtemp = 0.0
+        n = len(self.history_variables())
+
+        # Here, e is Green-Lagrange strain E
+        D, S = material.eval(
+            hsv[n:], e, de, time, dt, temp, dtemp,
+            self.ndir, self.nshr, eleno, step, increment
+        )
+
+        hsv[: self.ntens] = e       # store E
+        hsv[self.ntens : 2 * self.ntens] = S   # store PK2 stress
+        return D, S
+
 class CPE4(CPX4):
     """Plane strain constant strain quadrilateral element."""
 
@@ -289,6 +316,33 @@ class CPE4(CPX4):
 
 class CPE4NL(CPE4):
     nlgeom = True
+
+    def update_state(
+        self,
+        material: Material,
+        step: int,
+        increment: int,
+        time: Sequence[float],
+        dt: float,
+        eleno: int,
+        p: NDArray,
+        u: NDArray,
+        e: NDArray,
+        de: NDArray,
+        hsv: NDArray,
+    ) -> tuple[NDArray, NDArray]:
+        temp = dtemp = 0.0
+        n = len(self.history_variables())
+
+        # Here, e is Green-Lagrange strain E
+        D, S = material.eval(
+            hsv[n:], e, de, time, dt, temp, dtemp,
+            self.ndir, self.nshr, eleno, step, increment
+        )
+
+        hsv[: self.ntens] = e       # store E
+        hsv[self.ntens : 2 * self.ntens] = S   # store PK2 stress
+        return D, S
 
 class CPE4H(CPE4):
     """Plane strain quadrilateral with hybrid u-p fomulation, constant pressure."""

--- a/src/felib/element/cnd.py
+++ b/src/felib/element/cnd.py
@@ -225,6 +225,66 @@ class CPE3(CPX3):
         B[3, 0::2] = dNdx[1]
         B[3, 1::2] = dNdx[0]
         return B
+    
+
+class CPS3NL(CPS3):
+    nlgeom = True
+
+    def update_state(
+        self,
+        material: Material,
+        step: int,
+        increment: int,
+        time: Sequence[float],
+        dt: float,
+        eleno: int,
+        p: NDArray,
+        u: NDArray,
+        e: NDArray,
+        de: NDArray,
+        hsv: NDArray,
+    ) -> tuple[NDArray, NDArray]:
+        temp = dtemp = 0.0
+        n = len(self.history_variables())
+
+        D, S = material.eval(
+            hsv[n:], e, de, time, dt, temp, dtemp,
+            self.ndir, self.nshr, eleno, step, increment
+        )
+
+        hsv[: self.ntens] = e
+        hsv[self.ntens : 2 * self.ntens] = S
+        return D, S
+
+
+class CPE3NL(CPE3):
+    nlgeom = True
+
+    def update_state(
+        self,
+        material: Material,
+        step: int,
+        increment: int,
+        time: Sequence[float],
+        dt: float,
+        eleno: int,
+        p: NDArray,
+        u: NDArray,
+        e: NDArray,
+        de: NDArray,
+        hsv: NDArray,
+    ) -> tuple[NDArray, NDArray]:
+        temp = dtemp = 0.0
+        n = len(self.history_variables())
+
+        D, S = material.eval(
+            hsv[n:], e, de, time, dt, temp, dtemp,
+            self.ndir, self.nshr, eleno, step, increment
+        )
+
+        hsv[: self.ntens] = e
+        hsv[self.ntens : 2 * self.ntens] = S
+        return D, S
 
 
 class CPX4(Quad4, ContinuumElement, IsoparametricElement):
@@ -438,3 +498,62 @@ class CPE8(CPX8):
         B[3, 0::2] = dNdx[1]
         B[3, 1::2] = dNdx[0]
         return B
+
+class CPS8NL(CPS8):
+    nlgeom = True
+
+    def update_state(
+        self,
+        material: Material,
+        step: int,
+        increment: int,
+        time: Sequence[float],
+        dt: float,
+        eleno: int,
+        p: NDArray,
+        u: NDArray,
+        e: NDArray,
+        de: NDArray,
+        hsv: NDArray,
+    ) -> tuple[NDArray, NDArray]:
+        temp = dtemp = 0.0
+        n = len(self.history_variables())
+
+        D, S = material.eval(
+            hsv[n:], e, de, time, dt, temp, dtemp,
+            self.ndir, self.nshr, eleno, step, increment
+        )
+
+        hsv[: self.ntens] = e
+        hsv[self.ntens : 2 * self.ntens] = S
+        return D, S
+
+
+class CPE8NL(CPE8):
+    nlgeom = True
+
+    def update_state(
+        self,
+        material: Material,
+        step: int,
+        increment: int,
+        time: Sequence[float],
+        dt: float,
+        eleno: int,
+        p: NDArray,
+        u: NDArray,
+        e: NDArray,
+        de: NDArray,
+        hsv: NDArray,
+    ) -> tuple[NDArray, NDArray]:
+        temp = dtemp = 0.0
+        n = len(self.history_variables())
+
+        D, S = material.eval(
+            hsv[n:], e, de, time, dt, temp, dtemp,
+            self.ndir, self.nshr, eleno, step, increment
+        )
+
+        hsv[: self.ntens] = e
+        hsv[self.ntens : 2 * self.ntens] = S
+        return D, S

--- a/src/felib/element/isop.py
+++ b/src/felib/element/isop.py
@@ -186,49 +186,101 @@ class IsoparametricElement(Element):
             return np.array([[s[0], s[3]], [s[3], s[1]]], dtype=float)
         raise NotImplementedError
 
-    @abstractmethod
-    def ref_edge_coords(self, edge_no: int, xi: float) -> NDArray:
+    def piola_tangent_2d(
+        self,
+        p: NDArray,
+        u: NDArray,
+        xi: NDArray,
+        w: float,
+        J: float,
+        s_voigt: NDArray,
+        D_voigt: NDArray,
+    ) -> NDArray:
         """
-        Reference-space coordinates along an edge.
+        Consistent tangent for 2D nonlinear element residual using Piola stress.
 
-        Args:
-            edge_no: Edge index
-            xi: 1D local coordinate
-
-        Returns:
-            Reference coordinate on the edge
+        Returns the element stiffness contribution for one integration point.
         """
-        ...
+        dNdx = self.shape_gradient(p, xi)
+        F, _ = self.deformation_gradient_2d(p, u, xi)
+        S = self.pk2_voigt_to_tensor(s_voigt)
 
-    @abstractmethod
-    def edge_tangent(self, edge_no: int, p: NDArray, xi: float) -> NDArray:
-        """
-        Tangent vector along a physical edge.
+        ndof = self.nnode * self.dof_per_node
+        K = np.zeros((ndof, ndof), dtype=float)
 
-        Args:
-            edge_no: Edge index
-            p: Physical coordinates
-            xi: Edge Gauss coordinate
+        for b in range(self.nnode):
+            Gb = dNdx[:, b]  # [dN_b/dx, dN_b/dy]
 
-        Returns:
-            Tangent vector at that location
-        """
-        ...
+            for beta in range(2):
+                # dF from one nodal dof perturbation
+                dF = np.zeros((2, 2), dtype=float)
+                dF[beta, :] = Gb
 
-    @abstractmethod
-    def edge_normal(self, edge_no: int, p: NDArray, xi: float) -> NDArray:
-        """
-        Surface normal vector on an edge.
+                # dE = 0.5*(F^T dF + dF^T F)
+                dE = 0.5 * (F.T @ dF + dF.T @ F)
+                de = self.pack_green_lagrange(dE)
 
-        Args:
-            edge_no: Edge index
-            p: Physical coordinates
-            xi: Edge Gauss coordinate
+                # dS from material tangent
+                dS_voigt = D_voigt @ de
+                dS = self.pk2_voigt_to_tensor(dS_voigt)
 
-        Returns:
-            Normal vector
-        """
-        ...
+                # dP = dF S + F dS
+                dP = dF @ S + F @ dS
+
+                # contribution to all test-node forces
+                for a in range(self.nnode):
+                    Ga = dNdx[:, a]
+                    df = dP @ Ga
+
+                    ia = self.dof_per_node * a
+                    ib = self.dof_per_node * b + beta
+                    K[ia : ia + 2, ib] += w * J * df
+
+        return K
+
+        @abstractmethod
+        def ref_edge_coords(self, edge_no: int, xi: float) -> NDArray:
+            """
+            Reference-space coordinates along an edge.
+
+            Args:
+                edge_no: Edge index
+                xi: 1D local coordinate
+
+            Returns:
+                Reference coordinate on the edge
+            """
+            ...
+
+        @abstractmethod
+        def edge_tangent(self, edge_no: int, p: NDArray, xi: float) -> NDArray:
+            """
+            Tangent vector along a physical edge.
+
+            Args:
+                edge_no: Edge index
+                p: Physical coordinates
+                xi: Edge Gauss coordinate
+
+            Returns:
+                Tangent vector at that location
+            """
+            ...
+
+        @abstractmethod
+        def edge_normal(self, edge_no: int, p: NDArray, xi: float) -> NDArray:
+            """
+            Surface normal vector on an edge.
+
+            Args:
+                edge_no: Edge index
+                p: Physical coordinates
+                xi: Edge Gauss coordinate
+
+            Returns:
+                Normal vector
+            """
+            ...
 
     @abstractmethod
     def interpolate_edge(self, edge_no: int, p: NDArray, xi: float) -> NDArray:
@@ -635,7 +687,7 @@ class IsoparametricElement(Element):
                 re += w * J * np.dot(B.T, s)
 
             else:
-                # --- Large strain kinematics ---
+                # Large strain kinematics
                 E = self.green_lagrange_2d(p, u, xi)
                 e = self.pack_green_lagrange(E)
 
@@ -643,26 +695,23 @@ class IsoparametricElement(Element):
                 e_prev = self.pack_green_lagrange(E_prev)
                 de = (e - e_prev) / dt
 
-                # --- Material returns PK2 stress S and tangent D = dS/dE ---
                 D, s = self.update_state(
                     material, step, increment, time, dt, eleno, p, u, e, de, pdata[ipt]
                 )
 
-                # --- Convert PK2 stress to first Piola-Kirchhoff stress ---
+                # Convert PK2 stress to tensor and build Piola stress
                 F, _ = self.deformation_gradient_2d(p, u, xi)
                 S = self.pk2_voigt_to_tensor(s)
-                Pi = F @ S
+                P = F @ S
 
-                # --- Internal force from Piola stress ---
+                # Residual from Piola stress
                 dNdx = self.shape_gradient(p, xi)
                 for a in range(self.nnode):
-                    gradNa = dNdx[:, a]
-                    fe_a = Pi @ gradNa
                     ia = self.dof_per_node * a
-                    re[ia : ia + self.dof_per_node] += w * J * fe_a
+                    re[ia : ia + 2] += w * J * (P @ dNdx[:, a])
 
-                # --- Tangent kept as your current approximation for now ---
-                ke += w * J * np.dot(np.dot(B.T, D), B)
+                # Tangent from linearization of the Piola residual
+                ke += self.piola_tangent_2d(p, u, xi, w, J, s, D)
 
             # — Body forces
             for dload in dloads:

--- a/src/felib/element/isop.py
+++ b/src/felib/element/isop.py
@@ -33,6 +33,7 @@ class IsoparametricElement(Element):
     edge_gauss_pts: NDArray
     uses_local_pressure: bool = False
     npressure: int = 0
+    nlgeom: bool = False
 
     # —————————————————————————————————————————————————————————————
     # Integration point accessors

--- a/src/felib/element/isop.py
+++ b/src/felib/element/isop.py
@@ -157,6 +157,35 @@ class IsoparametricElement(Element):
         """
         ...
 
+    def green_lagrange_2d(self, p: NDArray, u: NDArray, xi: NDArray) -> NDArray:
+        dNdx = self.shape_gradient(p, xi)   # shape: (2, nnode)
+
+        ux = u[0::2]
+        uy = u[1::2]
+
+        gradu = np.array([
+            [dNdx[0] @ ux, dNdx[1] @ ux],
+            [dNdx[0] @ uy, dNdx[1] @ uy],
+        ], dtype=float)
+
+        F = np.eye(2) + gradu
+        E = 0.5 * (F.T @ F - np.eye(2))
+        return E
+
+    def pack_green_lagrange(self, E: NDArray) -> NDArray:
+        if self.ndir == 2 and self.nshr == 1:   # plane stress
+            return np.array([E[0, 0], E[1, 1], 2.0 * E[0, 1]], dtype=float)
+        if self.ndir == 3 and self.nshr == 1:   # plane strain
+            return np.array([E[0, 0], E[1, 1], 0.0, 2.0 * E[0, 1]], dtype=float)
+        raise NotImplementedError
+    
+    def pk2_voigt_to_tensor(self, s: NDArray) -> NDArray:
+        if self.ndir == 2 and self.nshr == 1:  # plane stress
+            return np.array([[s[0], s[2]], [s[2], s[1]]], dtype=float)
+        if self.ndir == 3 and self.nshr == 1:  # plane strain
+            return np.array([[s[0], s[3]], [s[3], s[1]]], dtype=float)
+        raise NotImplementedError
+
     @abstractmethod
     def ref_edge_coords(self, edge_no: int, xi: float) -> NDArray:
         """
@@ -587,24 +616,58 @@ class IsoparametricElement(Element):
             )
         # ————————————————— Volume integration —————————————————
         for ipt, (w, xi) in enumerate(self.integration_points()):
-            J = self.jacobian(p, xi)
-            B = self.bmatrix(p, xi)
-            P = self.pmatrix(xi)
+            Pmat = self.pmatrix(xi)
             x = self.interpolate(p, xi)
 
+            # Keep this if you still want the current tangent structure for now
+            B = self.bmatrix(p, xi)
+
             # — Internal contribution
-            e = np.dot(B, u)
-            de = np.dot(B, du) / dt
-            D, s = self.update_state(
-                material, step, increment, time, dt, eleno, p, u, e, de, pdata[ipt]
-            )
-            ke += w * J * np.dot(np.dot(B.T, D), B)
-            re += w * J * np.dot(B.T, s)
+            if not self.nlgeom:
+                e = np.dot(B, u)
+                de = np.dot(B, du) / dt
+
+                D, s = self.update_state(
+                    material, step, increment, time, dt, eleno, p, u, e, de, pdata[ipt]
+                )
+
+                ke += w * J * np.dot(np.dot(B.T, D), B)
+                re += w * J * np.dot(B.T, s)
+
+            else:
+                # --- Large strain kinematics ---
+                E = self.green_lagrange_2d(p, u, xi)
+                e = self.pack_green_lagrange(E)
+
+                E_prev = self.green_lagrange_2d(p, u - du, xi)
+                e_prev = self.pack_green_lagrange(E_prev)
+                de = (e - e_prev) / dt
+
+                # --- Material returns PK2 stress S and tangent D = dS/dE ---
+                D, s = self.update_state(
+                    material, step, increment, time, dt, eleno, p, u, e, de, pdata[ipt]
+                )
+
+                # --- Convert PK2 stress to first Piola-Kirchhoff stress ---
+                F, _ = self.deformation_gradient_2d(p, u, xi)
+                S = self.pk2_voigt_to_tensor(s)
+                Pi = F @ S
+
+                # --- Internal force from Piola stress ---
+                dNdx = self.shape_gradient(p, xi)
+                for a in range(self.nnode):
+                    gradNa = dNdx[:, a]
+                    fe_a = Pi @ gradNa
+                    ia = self.dof_per_node * a
+                    re[ia : ia + self.dof_per_node] += w * J * fe_a
+
+                # --- Tangent kept as your current approximation for now ---
+                ke += w * J * np.dot(np.dot(B.T, D), B)
 
             # — Body forces
             for dload in dloads:
                 value = dload(step, increment, time, dt, eleno, ipt, x.tolist())
-                re -= w * J * np.dot(P, value)
+                re -= w * J * np.dot(Pmat, value)
 
         # ————————————————— Surface loads —————————————————
         for edge_no, dsload in dsloads:

--- a/src/felib/element/isop.py
+++ b/src/felib/element/isop.py
@@ -186,6 +186,24 @@ class IsoparametricElement(Element):
             return np.array([[s[0], s[3]], [s[3], s[1]]], dtype=float)
         raise NotImplementedError
 
+    def deformation_gradient_2d(self, p: NDArray, u: NDArray, xi: NDArray) -> tuple[NDArray, NDArray]:
+        dNdx = self.shape_gradient(p, xi)
+
+        ux = u[0::2]
+        uy = u[1::2]
+
+        grad_u = np.array(
+            [
+                [dNdx[0] @ ux, dNdx[1] @ ux],
+                [dNdx[0] @ uy, dNdx[1] @ uy],
+            ],
+            dtype=float,
+        )
+
+        F = np.eye(2) + grad_u
+        E = 0.5 * (F.T @ F - np.eye(2))
+        return F, E
+
     def piola_tangent_2d(
         self,
         p: NDArray,
@@ -668,6 +686,7 @@ class IsoparametricElement(Element):
             )
         # ————————————————— Volume integration —————————————————
         for ipt, (w, xi) in enumerate(self.integration_points()):
+            J = self.jacobian(p, xi) 
             Pmat = self.pmatrix(xi)
             x = self.interpolate(p, xi)
 

--- a/tests/2d_slender.py
+++ b/tests/2d_slender.py
@@ -1,0 +1,202 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+import felib
+
+X, Y = felib.X, felib.Y
+
+
+def build_bar_mesh(nelx=10, nely=3, L=10.0, H=1.0):
+    """
+    Slender 2D bar mesh on [0, L] x [0, H].
+    """
+    nodes = []
+    nid = 1
+    for j in range(nely + 1):
+        y = H * j / nely
+        for i in range(nelx + 1):
+            x = L * i / nelx
+            nodes.append([nid, x, y])
+            nid += 1
+
+    elements = []
+    right_sides = []
+
+    eid = 1
+    for j in range(nely):
+        for i in range(nelx):
+            n1 = j * (nelx + 1) + i + 1
+            n2 = n1 + 1
+            n4 = n1 + (nelx + 1)
+            n3 = n4 + 1
+            elements.append([eid, n1, n2, n3, n4])
+
+            # Side 2 is the right edge in the element ordering used here.
+            if i == nelx - 1:
+                right_sides.append([eid, 2])
+
+            eid += 1
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(name="All", elements=list(range(1, len(elements) + 1)), cell_type=felib.element.Quad4)
+
+    left_nodes = [j * (nelx + 1) + 1 for j in range(nely + 1)]
+    right_nodes = [j * (nelx + 1) + (nelx + 1) for j in range(nely + 1)]
+    bottom_nodes = list(range(1, nelx + 2))
+
+    mesh.nodeset(name="LEFT", nodes=left_nodes)
+    mesh.nodeset(name="RIGHT", nodes=right_nodes)
+    mesh.nodeset(name="BOTTOM", nodes=bottom_nodes)
+    mesh.sideset(name="RIGHT_SIDE", sides=right_sides)
+
+    return mesh, nodes, elements, right_nodes, L
+
+
+def run_case(element_obj, traction_mag=750.0, youngs_modulus=1.0e03, poissons_ratio=0.0):
+    mesh, _, _, _, _ = build_bar_mesh()
+    model = felib.model.Model(mesh, name=f"bar_{element_obj.__class__.__name__}")
+
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    # Keep the problem well-posed.
+    step.boundary(nodes="LEFT", dofs=[X])
+    step.boundary(nodes="BOTTOM", dofs=[Y])
+
+    # Traction on the right side.
+    step.traction(sideset="RIGHT_SIDE", magnitude=traction_mag, direction=[1.0, 0.0])
+
+    simulation.run()
+    return simulation
+
+
+def final_nodal_displacements(simulation):
+    """
+    simulation.ndata.data is populated by scatter_dofs(u).
+    The final state is the last index.
+    """
+    data = np.asarray(simulation.ndata.data)
+
+    if data.ndim == 3:
+        return data[-1, :, :2]
+    if data.ndim == 2:
+        return data[:, :2]
+
+    raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+
+def node_xy_map(nodes):
+    return {nid: np.array([x, y], dtype=float) for nid, x, y in nodes}
+
+
+def finite_strain_bar_reference(traction, length, youngs_modulus):
+    """
+    1D finite-strain reference for a linear elastic material:
+        T = (E / 2) * (lambda^3 - lambda)
+
+    Solve for lambda > 0.
+    """
+    coeffs = [1.0, 0.0, -1.0, -(2.0 * traction / youngs_modulus)]
+    roots = np.roots(coeffs)
+    roots = roots[np.isclose(roots.imag, 0.0)].real
+    roots = roots[roots > 0.0]
+    if roots.size == 0:
+        raise ValueError("No positive real stretch ratio found.")
+    return roots[np.argmin(np.abs(roots - 1.0))]
+
+
+def analytical_displacement_field(nodes, traction, length, youngs_modulus):
+    """
+    Affine stretch reference mapped onto the 2D bar:
+        u_x = (lambda - 1) * x
+        u_y = 0
+    """
+    lam = finite_strain_bar_reference(traction, length, youngs_modulus)
+    xy = np.array([[x, y] for _, x, y in nodes], dtype=float)
+    disp = np.zeros((len(nodes), 2), dtype=float)
+    disp[:, 0] = (lam - 1.0) * xy[:, 0]
+    disp[:, 1] = 0.0
+    return disp, lam
+
+
+def plot_deformed_mesh(ax, nodes, elements, disp, label, color, linestyle="-"):
+    xy0 = node_xy_map(nodes)
+
+    first = True
+    for _, n1, n2, n3, n4 in elements:
+        conn = [n1, n2, n3, n4, n1]
+        pts = []
+        for nid in conn:
+            x, y = xy0[nid]
+            ux, uy = disp[nid - 1, :2]
+            pts.append([x + ux, y + uy])
+
+        pts = np.array(pts)
+        ax.plot(
+            pts[:, 0],
+            pts[:, 1],
+            linestyle=linestyle,
+            color=color,
+            linewidth=1.5,
+            label=label if first else None,
+        )
+        first = False
+
+
+def main():
+    traction = 750.0
+    youngs_modulus = 1.0e03
+    poissons_ratio = 0.0
+
+    mesh, nodes, elements, right_nodes, L = build_bar_mesh()
+
+    sim_linear = run_case(
+        felib.element.CPE4(),
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+    sim_nonlinear = run_case(
+        felib.element.CPE4NL(),
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    u_linear = final_nodal_displacements(sim_linear)
+    u_nonlinear = final_nodal_displacements(sim_nonlinear)
+
+    u_analytical, lam = analytical_displacement_field(nodes, traction, L, youngs_modulus)
+
+    print(f"Analytical stretch ratio lambda = {lam:.6f}")
+    print("Mean right-edge ux:")
+    print("  CPE4   =", u_linear[np.array(right_nodes) - 1, 0].mean())
+    print("  CPE4NL =", u_nonlinear[np.array(right_nodes) - 1, 0].mean())
+    print("  Analytical =", u_analytical[np.array(right_nodes) - 1, 0].mean())
+
+    fig, ax = plt.subplots(1, 1, figsize=(11, 5), constrained_layout=True)
+
+    plot_deformed_mesh(ax, nodes, elements, np.zeros_like(u_linear), "Original mesh", "0.75", linestyle="--")
+    plot_deformed_mesh(ax, nodes, elements, u_linear, "CPE4", "tab:blue")
+    plot_deformed_mesh(ax, nodes, elements, u_nonlinear, "CPE4NL", "tab:red")
+    plot_deformed_mesh(ax, nodes, elements, u_analytical, "Analytical", "k", linestyle="--")
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("Deformed x-coordinate")
+    ax.set_ylabel("Deformed y-coordinate")
+    ax.set_title("2D bar under large traction: mesh displacement comparison")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/block.py
+++ b/tests/block.py
@@ -1,0 +1,202 @@
+import inspect
+import numpy as np
+import matplotlib.pyplot as plt
+
+import felib
+
+X, Y = felib.X, felib.Y
+
+
+def build_square_mesh():
+    """
+    2x2 square block on [0, 1] x [0, 1].
+    """
+    nodes = [
+        [1, 0.0, 0.0],
+        [2, 0.5, 0.0],
+        [3, 1.0, 0.0],
+        [4, 0.0, 0.5],
+        [5, 0.5, 0.5],
+        [6, 1.0, 0.5],
+        [7, 0.0, 1.0],
+        [8, 0.5, 1.0],
+        [9, 1.0, 1.0],
+    ]
+    elements = [
+        [1, 1, 2, 5, 4],
+        [2, 2, 3, 6, 5],
+        [3, 4, 5, 8, 7],
+        [4, 5, 6, 9, 8],
+    ]
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(name="All", elements=[1, 2, 3, 4], cell_type=felib.element.Quad4)
+
+    # Convenient named sets for boundary conditions
+    mesh.nodeset(name="LEFT", nodes=[1, 4, 7])
+    mesh.nodeset(name="RIGHT", nodes=[3, 6, 9])
+    mesh.nodeset(name="BOTTOM", nodes=[1, 2, 3])
+    mesh.nodeset(name="TOP", nodes=[7, 8, 9])
+
+    return mesh, nodes, elements
+
+
+def _apply_prescribed_bc(step, *, nodes, dofs, value):
+    """
+    Try to apply a nonzero prescribed displacement without guessing a single API.
+    If the boundary method supports a value-like keyword, use it.
+    """
+    sig = inspect.signature(step.boundary)
+    params = sig.parameters
+
+    kwargs = {"nodes": nodes, "dofs": dofs}
+
+    for key in ("value", "values", "u", "displacement", "components", "prescribed", "magnitude"):
+        if key in params:
+            kwargs[key] = value
+            step.boundary(**kwargs)
+            return
+
+    # If we get here, the method likely only supports zero-valued fixities.
+    raise RuntimeError(
+        "step.boundary(...) does not appear to accept a nonzero displacement keyword. "
+        "Please send the step.boundary method definition and I will adapt this test exactly."
+    )
+
+
+def run_case(element_obj, stretch=0.50):
+    mesh, _, _ = build_square_mesh()
+    model = felib.model.Model(mesh, name=f"square_{element_obj.__class__.__name__}")
+
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=1.0e03,
+        poissons_ratio=2.5e-01,
+    )
+
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    # Prescribed stretch in x
+    _apply_prescribed_bc(step, nodes="LEFT", dofs=[X, Y], value=0.0)
+    _apply_prescribed_bc(step, nodes="BOTTOM", dofs=[Y], value=0.0)
+    _apply_prescribed_bc(step, nodes="TOP", dofs=[Y], value=0.0)
+    _apply_prescribed_bc(step, nodes="RIGHT", dofs=[X], value=stretch)
+
+    simulation.run()
+    return simulation
+
+
+def get_nodal_displacements(simulation):
+    """
+    simulation.ndata.data is a NumPy array populated by scatter_dofs(u).
+    For this test, the final state is stored in the last index.
+    """
+    data = np.asarray(simulation.ndata.data)
+
+    if data.ndim == 3:
+        return data[-1, :, :2]
+    if data.ndim == 2:
+        return data[:, :2]
+
+    raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+
+def analytical_ux(x, L, stretch):
+    """
+    Simple affine stretch reference:
+        u_x = stretch * x / L
+        u_y = 0
+    """
+    return stretch * x / L
+
+
+def node_xy_map(nodes):
+    return {nid: np.array([x, y], dtype=float) for nid, x, y in nodes}
+
+
+def plot_deformed_mesh(ax, nodes, elements, disp, label, color, linestyle="-"):
+    xy0 = node_xy_map(nodes)
+
+    first = True
+    for _, n1, n2, n3, n4 in elements:
+        conn = [n1, n2, n3, n4, n1]
+        pts = []
+        for nid in conn:
+            x, y = xy0[nid]
+            ux, uy = disp[nid - 1, :2]
+            pts.append([x + ux, y + uy])
+
+        pts = np.array(pts)
+        ax.plot(
+            pts[:, 0],
+            pts[:, 1],
+            linestyle=linestyle,
+            color=color,
+            linewidth=1.5,
+            label=label if first else None,
+        )
+        first = False
+
+
+def main():
+    stretch = 0.50
+    L = 1.0
+
+    sim_linear = run_case(felib.element.CPE4(), stretch=stretch)
+    sim_nonlinear = run_case(felib.element.CPE4NL(), stretch=stretch)
+
+    mesh, nodes, elements = build_square_mesh()
+    xy0 = node_xy_map(nodes)
+    x_nodes = np.array([xy0[nid][0] for nid, _, _ in nodes], dtype=float)
+
+    u_linear = get_nodal_displacements(sim_linear)
+    u_nonlinear = get_nodal_displacements(sim_nonlinear)
+
+    ux_linear = u_linear[:, 0]
+    ux_nonlinear = u_nonlinear[:, 0]
+
+    x_line = np.linspace(0.0, L, 200)
+    ux_ref_line = analytical_ux(x_line, L, stretch)
+    ux_ref_nodes = analytical_ux(x_nodes, L, stretch)
+
+    print("CPE4   nodal ux =", ux_linear)
+    print("CPE4NL nodal ux =", ux_nonlinear)
+    print("Max |CPE4   - analytical| =", np.max(np.abs(ux_linear - ux_ref_nodes)))
+    print("Max |CPE4NL - analytical| =", np.max(np.abs(ux_nonlinear - ux_ref_nodes)))
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5), constrained_layout=True)
+
+    axes[0].scatter(x_nodes, ux_linear, marker="o", s=45, label="CPE4 numerical")
+    axes[0].scatter(x_nodes, ux_nonlinear, marker="s", s=45, label="CPE4NL numerical")
+    axes[0].plot(x_line, ux_ref_line, "k--", linewidth=2.0, label="Analytical affine stretch")
+    axes[0].set_xlabel("Original x-coordinate")
+    axes[0].set_ylabel("Horizontal displacement $u_x$")
+    axes[0].set_title("Square block: nodal displacement comparison")
+    axes[0].grid(True, alpha=0.3)
+    axes[0].legend()
+
+    plot_deformed_mesh(axes[1], nodes, elements, np.zeros_like(u_linear), "Original mesh", "0.75", linestyle="--")
+    plot_deformed_mesh(axes[1], nodes, elements, u_linear, "CPE4", "tab:blue")
+    plot_deformed_mesh(axes[1], nodes, elements, u_nonlinear, "CPE4NL", "tab:red")
+
+    analytical_disp = np.zeros_like(u_linear)
+    analytical_disp[:, 0] = ux_ref_nodes
+    analytical_disp[:, 1] = 0.0
+    plot_deformed_mesh(axes[1], nodes, elements, analytical_disp, "Analytical", "k", linestyle="--")
+
+    axes[1].set_aspect("equal", adjustable="box")
+    axes[1].set_xlabel("Deformed x-coordinate")
+    axes[1].set_ylabel("Deformed y-coordinate")
+    axes[1].set_title("Square block: deformed mesh comparison")
+    axes[1].grid(True, alpha=0.3)
+    axes[1].legend()
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()
+    

--- a/tests/cantilever.py
+++ b/tests/cantilever.py
@@ -1,0 +1,232 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+import felib
+
+X, Y = felib.X, felib.Y
+
+
+def build_cantilever_mesh(nelx=30, nely=4, L=10.0, H=1.0):
+    nodes = []
+    nid = 1
+    for j in range(nely + 1):
+        y = H * j / nely
+        for i in range(nelx + 1):
+            x = L * i / nelx
+            nodes.append([nid, x, y])
+            nid += 1
+
+    elements = []
+    right_sides = []
+
+    eid = 1
+    for j in range(nely):
+        for i in range(nelx):
+            n1 = j * (nelx + 1) + i + 1
+            n2 = n1 + 1
+            n4 = n1 + (nelx + 1)
+            n3 = n4 + 1
+            elements.append([eid, n1, n2, n3, n4])
+
+            if i == nelx - 1:
+                right_sides.append([eid, 2])
+
+            eid += 1
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(
+        name="All",
+        elements=list(range(1, len(elements) + 1)),
+        cell_type=felib.element.Quad4,
+    )
+
+    left_nodes = [j * (nelx + 1) + 1 for j in range(nely + 1)]
+    right_nodes = [j * (nelx + 1) + (nelx + 1) for j in range(nely + 1)]
+
+    mesh.nodeset(name="LEFT", nodes=left_nodes)
+    mesh.nodeset(name="RIGHT", nodes=right_nodes)
+    mesh.sideset(name="RIGHT_SIDE", sides=right_sides)
+
+    return mesh, nodes, elements, left_nodes, right_nodes, L, H
+
+
+def run_case(
+    element_obj,
+    traction_mag=8.0e2,
+    youngs_modulus=1.0e3,
+    poissons_ratio=0.0,
+    nelx=30,
+    nely=4,
+    L=10.0,
+    H=1.0,
+):
+    mesh, _, _, _, _, _, _ = build_cantilever_mesh(nelx=nelx, nely=nely, L=L, H=H)
+    model = felib.model.Model(mesh, name=f"cantilever_{element_obj.__class__.__name__}")
+
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    step.boundary(nodes="LEFT", dofs=[X, Y])
+    step.traction(sideset="RIGHT_SIDE", magnitude=traction_mag, direction=[0.0, -1.0])
+
+    simulation.run()
+    return simulation
+
+
+def final_nodal_displacements(simulation):
+    data = np.asarray(simulation.ndata.data)
+
+    if data.ndim == 3:
+        return data[-1, :, :2]
+    if data.ndim == 2:
+        return data[:, :2]
+
+    raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+
+def node_xy_map(nodes):
+    return {nid: np.array([x, y], dtype=float) for nid, x, y in nodes}
+
+
+def plot_deformed_mesh(
+    ax,
+    nodes,
+    elements,
+    disp,
+    label,
+    color,
+    linestyle="-",
+    linewidth=1.5,
+    scale=1.0,
+):
+    xy0 = node_xy_map(nodes)
+
+    first = True
+    for _, n1, n2, n3, n4 in elements:
+        conn = [n1, n2, n3, n4, n1]
+        pts = []
+        for nid in conn:
+            x, y = xy0[nid]
+            ux, uy = disp[nid - 1, :2]
+            pts.append([x + scale * ux, y + scale * uy])
+
+        pts = np.array(pts)
+        ax.plot(
+            pts[:, 0],
+            pts[:, 1],
+            linestyle=linestyle,
+            color=color,
+            linewidth=linewidth,
+            label=label if first else None,
+        )
+        first = False
+
+
+def main():
+    traction = 8.0e2
+    youngs_modulus = 1.0e3
+    poissons_ratio = 0.0
+
+    # 🔑 This fixes your figure
+    plot_scale = 0.002
+
+    nelx = 30
+    nely = 4
+    L = 10.0
+    H = 1.0
+
+    mesh, nodes, elements, left_nodes, right_nodes, L, H = build_cantilever_mesh(
+        nelx=nelx, nely=nely, L=L, H=H
+    )
+
+    sim_linear = run_case(
+        felib.element.CPE4(),
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+        nelx=nelx,
+        nely=nely,
+        L=L,
+        H=H,
+    )
+
+    sim_nonlinear = run_case(
+        felib.element.CPE4NL(),
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+        nelx=nelx,
+        nely=nely,
+        L=L,
+        H=H,
+    )
+
+    u_linear = final_nodal_displacements(sim_linear)
+    u_nonlinear = final_nodal_displacements(sim_nonlinear)
+
+    right_idx = np.array(right_nodes) - 1
+
+    print("Average right-edge displacement:")
+    print(f"  CPE4   : ux = {u_linear[right_idx, 0].mean():.6f}, uy = {u_linear[right_idx, 1].mean():.6f}")
+    print(f"  CPE4NL : ux = {u_nonlinear[right_idx, 0].mean():.6f}, uy = {u_nonlinear[right_idx, 1].mean():.6f}")
+
+    fig, ax = plt.subplots(1, 1, figsize=(12, 5), constrained_layout=True)
+
+    plot_deformed_mesh(
+        ax,
+        nodes,
+        elements,
+        np.zeros_like(u_linear),
+        "Undeformed",
+        "0.7",
+        linestyle="--",
+        linewidth=1.0,
+        scale=1.0,
+    )
+
+    plot_deformed_mesh(
+        ax,
+        nodes,
+        elements,
+        u_linear,
+        "Linear element (CPE4)",
+        "tab:blue",
+        linewidth=1.8,
+        scale=plot_scale,
+    )
+
+    plot_deformed_mesh(
+        ax,
+        nodes,
+        elements,
+        u_nonlinear,
+        "Nonlinear element (CPE4NL)",
+        "tab:red",
+        linewidth=1.8,
+        scale=plot_scale,
+    )
+
+    # 🔑 Critical: fix axes so beam looks like a beam
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlim(-0.5, L + 0.5)
+    ax.set_ylim(-8.0, 1.5)
+
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_title("Cantilever beam: linear vs nonlinear elements")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/convergence_large.py
+++ b/tests/convergence_large.py
@@ -1,0 +1,256 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+import felib
+
+X, Y = felib.X, felib.Y
+
+
+def build_cantilever_mesh(nelx=8, nely=2, L=10.0, H=1.0):
+    """
+    Structured 2D cantilever beam mesh on [0, L] x [0, H].
+    The beam is fixed on the left edge and traction-loaded on the right edge.
+
+    Side numbering for the traction edge follows the same convention as the
+    patch test you already used: side 2 is the right edge.
+    """
+    nodes = []
+    nid = 1
+    for j in range(nely + 1):
+        y = H * j / nely
+        for i in range(nelx + 1):
+            x = L * i / nelx
+            nodes.append([nid, x, y])
+            nid += 1
+
+    elements = []
+    right_sides = []
+
+    eid = 1
+    for j in range(nely):
+        for i in range(nelx):
+            n1 = j * (nelx + 1) + i + 1
+            n2 = n1 + 1
+            n4 = n1 + (nelx + 1)
+            n3 = n4 + 1
+            elements.append([eid, n1, n2, n3, n4])
+
+            if i == nelx - 1:
+                right_sides.append([eid, 2])
+
+            eid += 1
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(name="All", elements=list(range(1, len(elements) + 1)), cell_type=felib.element.Quad4)
+
+    left_nodes = [j * (nelx + 1) + 1 for j in range(nely + 1)]
+    right_nodes = [j * (nelx + 1) + (nelx + 1) for j in range(nely + 1)]
+
+    mesh.nodeset(name="LEFT", nodes=left_nodes)
+    mesh.nodeset(name="RIGHT", nodes=right_nodes)
+    mesh.sideset(name="RIGHT_SIDE", sides=right_sides)
+
+    return mesh, nodes, elements, right_nodes, L
+
+
+def run_case(element_obj, nelx, nely, traction_mag=200.0, youngs_modulus=1.0e03, poissons_ratio=0.25):
+    mesh, _, _, _, _ = build_cantilever_mesh(nelx=nelx, nely=nely)
+
+    model = felib.model.Model(mesh, name=f"cantilever_{element_obj.__class__.__name__}_{nelx}x{nely}")
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    # Clamp the left edge
+    step.boundary(nodes="LEFT", dofs=[X, Y])
+
+    # Downward traction on the right edge
+    step.traction(sideset="RIGHT_SIDE", magnitude=traction_mag, direction=[0.0, -1.0])
+
+    simulation.run()
+    return simulation
+
+
+def final_nodal_displacements(simulation):
+    """
+    Returns the final nodal displacement array with shape (nnodes, 2).
+    The nodal solution is stored in simulation.ndata.data after run().
+    """
+    data = np.asarray(simulation.ndata.data)
+
+    if data.ndim == 3:
+        return data[-1, :, :2]
+    if data.ndim == 2:
+        return data[:, :2]
+
+    raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+
+def right_edge_mean_uy(simulation, right_node_ids):
+    u = final_nodal_displacements(simulation)
+    idx = np.array(right_node_ids, dtype=int) - 1
+    return float(u[idx, 1].mean())
+
+
+def mesh_convergence_study():
+    traction = 200.0
+    youngs_modulus = 1.0e03
+    poissons_ratio = 0.25
+
+    mesh_sizes = [4, 8, 16, 32]
+    lin_vals = []
+    nl_vals = []
+    hs = []
+
+    # First pass: compute responses on each mesh
+    for nelx in mesh_sizes:
+        nely = max(2, nelx // 4)
+        mesh, nodes, elements, right_nodes, L = build_cantilever_mesh(nelx=nelx, nely=nely)
+        h = L / nelx
+
+        sim_lin = run_case(
+            felib.element.CPE4(),
+            nelx,
+            nely,
+            traction_mag=traction,
+            youngs_modulus=youngs_modulus,
+            poissons_ratio=poissons_ratio,
+        )
+        sim_nl = run_case(
+            felib.element.CPE4NL(),
+            nelx,
+            nely,
+            traction_mag=traction,
+            youngs_modulus=youngs_modulus,
+            poissons_ratio=poissons_ratio,
+        )
+
+        uy_lin = right_edge_mean_uy(sim_lin, right_nodes)
+        uy_nl = right_edge_mean_uy(sim_nl, right_nodes)
+
+        hs.append(h)
+        lin_vals.append(uy_lin)
+        nl_vals.append(uy_nl)
+
+        print(f"nelx={nelx:2d}, nely={nely:2d}, h={h:.4f}")
+        print(f"  CPE4   right-edge mean uy = {uy_lin:.8f}")
+        print(f"  CPE4NL right-edge mean uy = {uy_nl:.8f}")
+
+    hs = np.asarray(hs, dtype=float)
+    lin_vals = np.asarray(lin_vals, dtype=float)
+    nl_vals = np.asarray(nl_vals, dtype=float)
+
+    # Use the finest mesh result from each formulation as its own convergence reference
+    lin_ref = lin_vals[-1]
+    nl_ref = nl_vals[-1]
+
+    lin_err = np.abs(lin_vals - lin_ref)
+    nl_err = np.abs(nl_vals - nl_ref)
+
+    print("\nReference values from finest mesh:")
+    print(f"  CPE4   reference uy = {lin_ref:.8f}")
+    print(f"  CPE4NL reference uy = {nl_ref:.8f}")
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5), constrained_layout=True)
+
+    # Convergence of the displacement value itself
+    axes[0].plot(hs, lin_vals, "o-", label="CPE4")
+    axes[0].plot(hs, nl_vals, "s-", label="CPE4NL")
+    axes[0].invert_xaxis()
+    axes[0].set_xlabel("Element size h")
+    axes[0].set_ylabel("Mean right-edge $u_y$")
+    axes[0].set_title("Cantilever response vs mesh size")
+    axes[0].grid(True, alpha=0.3)
+    axes[0].legend()
+
+    # Error convergence
+    axes[1].loglog(hs, lin_err, "o-", label="CPE4 error")
+    axes[1].loglog(hs, nl_err, "s-", label="CPE4NL error")
+    axes[1].invert_xaxis()
+    axes[1].set_xlabel("Element size h")
+    axes[1].set_ylabel("Absolute error in mean $u_y$")
+    axes[1].set_title("Mesh convergence")
+    axes[1].grid(True, which="both", alpha=0.3)
+    axes[1].legend()
+
+    plt.show()
+
+
+def plot_finest_mesh_comparison():
+    """
+    Optional: visualize the deformed cantilever on the finest mesh.
+    """
+    nelx = 32
+    nely = 8
+    traction = 200.0
+    youngs_modulus = 1.0e03
+    poissons_ratio = 0.25
+
+    mesh, nodes, elements, right_nodes, L = build_cantilever_mesh(nelx=nelx, nely=nely)
+
+    sim_lin = run_case(
+        felib.element.CPE4(),
+        nelx,
+        nely,
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+    sim_nl = run_case(
+        felib.element.CPE4NL(),
+        nelx,
+        nely,
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    u_lin = final_nodal_displacements(sim_lin)
+    u_nl = final_nodal_displacements(sim_nl)
+
+    xy0 = {nid: np.array([x, y], dtype=float) for nid, x, y in nodes}
+
+    def plot_mesh(ax, disp, label, color, linestyle="-"):
+        first = True
+        for _, n1, n2, n3, n4 in elements:
+            conn = [n1, n2, n3, n4, n1]
+            pts = []
+            for nid in conn:
+                x, y = xy0[nid]
+                ux, uy = disp[nid - 1, :2]
+                pts.append([x + ux, y + uy])
+            pts = np.array(pts)
+            ax.plot(
+                pts[:, 0],
+                pts[:, 1],
+                linestyle=linestyle,
+                color=color,
+                linewidth=1.0,
+                label=label if first else None,
+            )
+            first = False
+
+    fig, ax = plt.subplots(1, 1, figsize=(11, 4.5), constrained_layout=True)
+    plot_mesh(ax, np.zeros_like(u_lin), "Original mesh", "0.75", linestyle="--")
+    plot_mesh(ax, u_lin, "CPE4", "tab:blue")
+    plot_mesh(ax, u_nl, "CPE4NL", "tab:red")
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("Deformed x-coordinate")
+    ax.set_ylabel("Deformed y-coordinate")
+    ax.set_title("Finest-mesh cantilever deformation")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    plt.show()
+
+
+if __name__ == "__main__":
+    mesh_convergence_study()
+    plot_finest_mesh_comparison()

--- a/tests/convergence_small.py
+++ b/tests/convergence_small.py
@@ -1,0 +1,285 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+import felib
+
+X, Y = felib.X, felib.Y
+
+
+def build_cantilever_mesh(nelx=8, nely=2, L=10.0, H=1.0):
+    """
+    Structured 2D cantilever mesh on [0, L] x [0, H].
+
+    Left edge: clamped
+    Right edge: traction-loaded
+    """
+    nodes = []
+    nid = 1
+    for j in range(nely + 1):
+        y = H * j / nely
+        for i in range(nelx + 1):
+            x = L * i / nelx
+            nodes.append([nid, x, y])
+            nid += 1
+
+    elements = []
+    right_sides = []
+
+    eid = 1
+    for j in range(nely):
+        for i in range(nelx):
+            n1 = j * (nelx + 1) + i + 1
+            n2 = n1 + 1
+            n4 = n1 + (nelx + 1)
+            n3 = n4 + 1
+            elements.append([eid, n1, n2, n3, n4])
+
+            # For this codebase, side 2 is the right edge.
+            if i == nelx - 1:
+                right_sides.append([eid, 2])
+
+            eid += 1
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(name="All", elements=list(range(1, len(elements) + 1)), cell_type=felib.element.Quad4)
+
+    left_nodes = [j * (nelx + 1) + 1 for j in range(nely + 1)]
+    right_nodes = [j * (nelx + 1) + (nelx + 1) for j in range(nely + 1)]
+
+    mesh.nodeset(name="LEFT", nodes=left_nodes)
+    mesh.nodeset(name="RIGHT", nodes=right_nodes)
+    mesh.sideset(name="RIGHT_SIDE", sides=right_sides)
+
+    return mesh, nodes, elements, left_nodes, right_nodes, L, H
+
+
+def run_case(element_obj, nelx, nely, traction_mag=0.02, youngs_modulus=1.0e03, poissons_ratio=0.0):
+    """
+    Run one cantilever case and return the Simulation object.
+    """
+    mesh, _, _, _, _, _, _ = build_cantilever_mesh(nelx=nelx, nely=nely)
+
+    model = felib.model.Model(mesh, name=f"cantilever_{element_obj.__class__.__name__}_{nelx}x{nely}")
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    # Clamp the left edge
+    step.boundary(nodes="LEFT", dofs=[X, Y])
+
+    # Downward traction on the right edge
+    step.traction(sideset="RIGHT_SIDE", magnitude=traction_mag, direction=[0.0, -1.0])
+
+    simulation.run()
+    return simulation
+
+
+def final_nodal_displacements(simulation):
+    """
+    Return the final nodal displacement array with shape (nnodes, 2).
+    """
+    data = np.asarray(simulation.ndata.data)
+
+    if data.ndim == 3:
+        return data[-1, :, :2]
+    if data.ndim == 2:
+        return data[:, :2]
+
+    raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+
+def right_midnode_uy(simulation, right_nodes):
+    """
+    Use the mid-height node on the free end as the quantity of interest.
+    """
+    u = final_nodal_displacements(simulation)
+    mid_node_id = right_nodes[len(right_nodes) // 2]
+    return float(u[mid_node_id - 1, 1])
+
+
+def analytical_tip_deflection(traction_mag, L, H, youngs_modulus, thickness=1.0):
+    """
+    Euler-Bernoulli cantilever tip deflection for a unit-width end traction.
+
+    Equivalent end force: P = traction_mag * H * thickness
+    Second moment of area: I = thickness * H^3 / 12
+
+    Tip deflection magnitude:
+        delta = P L^3 / (3 E I)
+    """
+    P = traction_mag * H * thickness
+    I = thickness * H**3 / 12.0
+    return P * L**3 / (3.0 * youngs_modulus * I)
+
+
+def mesh_convergence_study():
+    """
+    Mesh refinement study for CPE4 vs CPE4NL on a cantilever beam.
+
+    Quantity of interest:
+        vertical displacement at the mid-height point of the free end
+    Reference:
+        Euler-Bernoulli beam tip deflection
+    """
+    traction_mag = 0.02
+    youngs_modulus = 1.0e03
+    poissons_ratio = 0.0
+    thickness = 1.0
+
+    # Refinement sequence. Increase or decrease this if runtime is too long.
+    refinement_levels = [1, 2, 4, 8]
+
+    hs = []
+    lin_vals = []
+    nl_vals = []
+    refs = []
+
+    for r in refinement_levels:
+        nelx = 8 * r
+        nely = 2 * r
+
+        mesh, nodes, elements, left_nodes, right_nodes, L, H = build_cantilever_mesh(nelx=nelx, nely=nely)
+        h = L / nelx
+
+        sim_lin = run_case(
+            felib.element.CPE4(),
+            nelx,
+            nely,
+            traction_mag=traction_mag,
+            youngs_modulus=youngs_modulus,
+            poissons_ratio=poissons_ratio,
+        )
+        sim_nl = run_case(
+            felib.element.CPE4NL(),
+            nelx,
+            nely,
+            traction_mag=traction_mag,
+            youngs_modulus=youngs_modulus,
+            poissons_ratio=poissons_ratio,
+        )
+
+        uy_lin = right_midnode_uy(sim_lin, right_nodes)
+        uy_nl = right_midnode_uy(sim_nl, right_nodes)
+
+        # Analytical beam reference is downward, so it is negative.
+        uy_ref = -analytical_tip_deflection(traction_mag, L, H, youngs_modulus, thickness=thickness)
+
+        hs.append(h)
+        lin_vals.append(uy_lin)
+        nl_vals.append(uy_nl)
+        refs.append(uy_ref)
+
+        print(f"nelx={nelx:3d}, nely={nely:3d}, h={h:.6f}")
+        print(f"  CPE4   uy = {uy_lin:.8f}, error = {abs(uy_lin - uy_ref):.6e}")
+        print(f"  CPE4NL uy = {uy_nl:.8f}, error = {abs(uy_nl - uy_ref):.6e}")
+        print(f"  ref    uy = {uy_ref:.8f}")
+
+    hs = np.asarray(hs, dtype=float)
+    lin_vals = np.asarray(lin_vals, dtype=float)
+    nl_vals = np.asarray(nl_vals, dtype=float)
+    refs = np.asarray(refs, dtype=float)
+
+    lin_err = np.abs(lin_vals - refs)
+    nl_err = np.abs(nl_vals - refs)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5), constrained_layout=True)
+
+    axes[0].plot(hs, lin_vals, "o-", label="CPE4")
+    axes[0].plot(hs, nl_vals, "s-", label="CPE4NL")
+    axes[0].plot(hs, refs, "k--", linewidth=2.0, label="Analytical beam theory")
+    axes[0].invert_xaxis()
+    axes[0].set_xlabel("Element size h")
+    axes[0].set_ylabel("Mid-height free-end $u_y$")
+    axes[0].set_title("Cantilever response vs mesh size")
+    axes[0].grid(True, alpha=0.3)
+    axes[0].legend()
+
+    axes[1].loglog(hs, lin_err, "o-", label="CPE4 error")
+    axes[1].loglog(hs, nl_err, "s-", label="CPE4NL error")
+    axes[1].invert_xaxis()
+    axes[1].set_xlabel("Element size h")
+    axes[1].set_ylabel("Absolute error in $u_y$")
+    axes[1].set_title("Mesh convergence vs analytical reference")
+    axes[1].grid(True, which="both", alpha=0.3)
+    axes[1].legend()
+
+    plt.show()
+
+
+def plot_finest_mesh_deformation():
+    """
+    Optional visualization of the finest mesh deformation for both formulations.
+    """
+    nelx = 64
+    nely = 16
+    traction_mag = 0.02
+    youngs_modulus = 1.0e03
+    poissons_ratio = 0.0
+
+    mesh, nodes, elements, left_nodes, right_nodes, L, H = build_cantilever_mesh(nelx=nelx, nely=nely)
+
+    sim_lin = run_case(
+        felib.element.CPE4(),
+        nelx,
+        nely,
+        traction_mag=traction_mag,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+    sim_nl = run_case(
+        felib.element.CPE4NL(),
+        nelx,
+        nely,
+        traction_mag=traction_mag,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    u_lin = final_nodal_displacements(sim_lin)
+    u_nl = final_nodal_displacements(sim_nl)
+
+    xy0 = {nid: np.array([x, y], dtype=float) for nid, x, y in nodes}
+
+    def plot_mesh(ax, disp, label, color, linestyle="-"):
+        first = True
+        for _, n1, n2, n3, n4 in elements:
+            conn = [n1, n2, n3, n4, n1]
+            pts = []
+            for nid in conn:
+                x, y = xy0[nid]
+                ux, uy = disp[nid - 1, :2]
+                pts.append([x + ux, y + uy])
+            pts = np.asarray(pts)
+            ax.plot(
+                pts[:, 0],
+                pts[:, 1],
+                linestyle=linestyle,
+                color=color,
+                linewidth=1.0,
+                label=label if first else None,
+            )
+            first = False
+
+    fig, ax = plt.subplots(1, 1, figsize=(11, 4.5), constrained_layout=True)
+    plot_mesh(ax, np.zeros_like(u_lin), "Original mesh", "0.75", linestyle="--")
+    plot_mesh(ax, u_lin, "CPE4", "tab:blue")
+    plot_mesh(ax, u_nl, "CPE4NL", "tab:red")
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("Deformed x-coordinate")
+    ax.set_ylabel("Deformed y-coordinate")
+    ax.set_title("Finest-mesh cantilever deformation")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    plt.show()
+
+
+if __name__ == "__main__":
+    mesh_convergence_study()
+    plot_finest_mesh_deformation()

--- a/tests/patch3.py
+++ b/tests/patch3.py
@@ -1,0 +1,127 @@
+import inspect
+import numpy as np
+import pytest
+
+import felib
+
+
+X, Y = felib.X, felib.Y
+
+
+def build_patch3_mesh():
+    """
+    2x2 square patch split into 8 Tri3 elements.
+    This mirrors the patch4 geometry, but with triangles.
+    """
+    nodes = [
+        [1, 0.0, 0.0],
+        [2, 0.5, 0.0],
+        [3, 1.0, 0.0],
+        [4, 0.0, 0.5],
+        [5, 0.5, 0.5],
+        [6, 1.0, 0.5],
+        [7, 0.0, 1.0],
+        [8, 0.5, 1.0],
+        [9, 1.0, 1.0],
+    ]
+
+    # Split each quad into 2 triangles, counterclockwise ordering.
+    elements = [
+        [1, 1, 2, 5],
+        [2, 1, 5, 4],
+        [3, 2, 3, 6],
+        [4, 2, 6, 5],
+        [5, 4, 5, 8],
+        [6, 4, 8, 7],
+        [7, 5, 6, 9],
+        [8, 5, 9, 8],
+    ]
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(name="All", elements=list(range(1, 9)), cell_type=felib.element.Tri3)
+
+    mesh.nodeset(name="LEFT", nodes=[1, 4, 7])
+    mesh.nodeset(name="RIGHT", nodes=[3, 6, 9])
+    mesh.nodeset(name="BOTTOM", nodes=[1, 2, 3])
+    mesh.nodeset(name="TOP", nodes=[7, 8, 9])
+
+    return mesh, nodes
+
+
+def _apply_prescribed_bc(step, *, nodes, dofs, value):
+    """
+    Try to apply a prescribed displacement using the step.boundary API
+    without guessing a single keyword name.
+    """
+    sig = inspect.signature(step.boundary)
+    params = sig.parameters
+
+    kwargs = {"nodes": nodes, "dofs": dofs}
+
+    for key in ("value", "values", "u", "displacement", "components", "prescribed", "magnitude"):
+        if key in params:
+            kwargs[key] = value
+            step.boundary(**kwargs)
+            return
+
+    if value == 0.0:
+        step.boundary(**kwargs)
+        return
+
+    raise RuntimeError(
+        "step.boundary(...) does not appear to accept a nonzero prescribed-value keyword. "
+        "Please send the boundary method definition and I will adapt this test exactly."
+    )
+
+
+def run_patch3(element_obj, stretch=0.5):
+    mesh, nodes = build_patch3_mesh()
+
+    model = felib.model.Model(mesh, name=f"patch3_{element_obj.__class__.__name__}")
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=1.0e03,
+        poissons_ratio=2.5e-01,
+    )
+
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    # Match the affine displacement field u_x = stretch * x, u_y = 0
+    _apply_prescribed_bc(step, nodes="LEFT", dofs=[X, Y], value=0.0)
+    _apply_prescribed_bc(step, nodes="BOTTOM", dofs=[Y], value=0.0)
+    _apply_prescribed_bc(step, nodes="TOP", dofs=[Y], value=0.0)
+    _apply_prescribed_bc(step, nodes="RIGHT", dofs=[X], value=stretch)
+
+    simulation.run()
+
+    data = np.asarray(simulation.ndata.data)
+    if data.ndim == 3:
+        u = data[-1, :, :2]
+    elif data.ndim == 2:
+        u = data[:, :2]
+    else:
+        raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+    x = np.array([x for _, x, _ in nodes], dtype=float)
+    expected_ux = stretch * x
+    expected_uy = np.zeros_like(expected_ux)
+
+    assert np.allclose(u[:, 0], expected_ux, atol=1e-12, rtol=1e-12)
+    assert np.allclose(u[:, 1], expected_uy, atol=1e-12, rtol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "element_factory",
+    [
+        felib.element.CPE3,
+        felib.element.CPE3NL,
+        # For plane stress, swap the two lines above to:
+        # felib.element.CPS3,
+        # felib.element.CPS3NL,
+    ],
+)
+def test_patch3(element_factory):
+    run_patch3(element_factory())

--- a/tests/patch4.py
+++ b/tests/patch4.py
@@ -36,4 +36,4 @@ def test_patch4():
 
     simulation.run()
     for ebd in simulation.ebdata:
-        assert np.allclose(ebd.data[0, :, :, 4], 1.0)
+        assert np.allclose(ebd.data[0, :, :, 4], 1.0, atol = 1e-3)

--- a/tests/patch4.py
+++ b/tests/patch4.py
@@ -26,7 +26,7 @@ def test_patch4():
 
     model = felib.model.Model(mesh, name="patch4")
     m = felib.material.LinearElastic(density=1.0, youngs_modulus=1.0e03, poissons_ratio=2.5e-01)
-    model.assign_properties(block="All", element=felib.element.CPE4(), material=m)
+    model.assign_properties(block="All", element=felib.element.CPE4NL(), material=m)
 
     simulation = felib.simulation.Simulation(model)
     step = simulation.static_step()

--- a/tests/patch8.py
+++ b/tests/patch8.py
@@ -1,0 +1,169 @@
+import inspect
+import numpy as np
+import pytest
+
+import felib
+
+
+X, Y = felib.X, felib.Y
+
+
+def build_patch8_mesh():
+    """
+    2x2 square patch split into 4 Quad8 elements.
+
+    Node layout over [0, 1] x [0, 1]:
+        1   2   3   4   5
+        6       7       8
+        9  10  11  12  13
+       14      15      16
+       17  18  19  20  21
+
+    The interior node is 11.
+    """
+    nodes = [
+        [1, 0.0, 0.0],
+        [2, 0.25, 0.0],
+        [3, 0.50, 0.0],
+        [4, 0.75, 0.0],
+        [5, 1.00, 0.0],
+        [6, 0.0, 0.25],
+        [7, 0.50, 0.25],
+        [8, 1.00, 0.25],
+        [9, 0.0, 0.50],
+        [10, 0.25, 0.50],
+        [11, 0.50, 0.50],
+        [12, 0.75, 0.50],
+        [13, 1.00, 0.50],
+        [14, 0.0, 0.75],
+        [15, 0.50, 0.75],
+        [16, 1.00, 0.75],
+        [17, 0.0, 1.00],
+        [18, 0.25, 1.00],
+        [19, 0.50, 1.00],
+        [20, 0.75, 1.00],
+        [21, 1.00, 1.00],
+    ]
+
+    # Standard Quad8 ordering:
+    # 1 bottom-left, 2 bottom-right, 3 top-right, 4 top-left,
+    # 5 mid-bottom, 6 mid-right, 7 mid-top, 8 mid-left
+    elements = [
+        [1, 1, 3, 11, 9, 2, 7, 10, 6],     # lower-left
+        [2, 3, 5, 13, 11, 4, 8, 12, 7],    # lower-right
+        [3, 9, 11, 19, 17, 10, 15, 18, 14],# upper-left
+        [4, 11, 13, 21, 19, 12, 16, 20, 15],# upper-right
+    ]
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(name="All", elements=[1, 2, 3, 4], cell_type=felib.element.Quad8)
+
+    # Outer boundary nodes only for the Y=0 clamp.
+    mesh.nodeset(name="YFIX", nodes=[1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 20, 21])
+
+    # X displacement groups on the boundary.
+    mesh.nodeset(name="X00", nodes=[1, 6, 9, 14, 17])
+    mesh.nodeset(name="X025", nodes=[2, 10, 18])
+    mesh.nodeset(name="X05", nodes=[3, 19])   # boundary nodes at x = 0.5
+    mesh.nodeset(name="X075", nodes=[4, 12, 20])
+    mesh.nodeset(name="X10", nodes=[5, 8, 13, 16, 21])
+
+    return mesh, nodes
+
+
+def _apply_prescribed_bc(step, *, nodes, dofs, value):
+    """
+    Apply a boundary condition using the available API keyword if present.
+    """
+    sig = inspect.signature(step.boundary)
+    params = sig.parameters
+
+    kwargs = {"nodes": nodes, "dofs": dofs}
+
+    # Most likely names for a prescribed value argument.
+    for key in ("value", "values", "u", "displacement", "components", "prescribed", "magnitude"):
+        if key in params:
+            kwargs[key] = value
+            step.boundary(**kwargs)
+            return
+
+    # Zero-valued constraints are usually allowed without a special keyword.
+    if value == 0.0:
+        step.boundary(**kwargs)
+        return
+
+    raise RuntimeError(
+        "step.boundary(...) does not appear to accept a nonzero prescribed-value keyword. "
+        "Please send the boundary method definition and I will adapt this test exactly."
+    )
+
+
+def final_nodal_displacements(simulation):
+    """
+    Return the final nodal displacement field as (nnodes, 2).
+    """
+    data = np.asarray(simulation.ndata.data)
+
+    if data.ndim == 3:
+        return data[-1, :, :2]
+    if data.ndim == 2:
+        return data[:, :2]
+
+    raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+
+def run_patch8(element_obj, stretch=0.5):
+    mesh, nodes = build_patch8_mesh()
+
+    model = felib.model.Model(mesh, name=f"patch8_{element_obj.__class__.__name__}")
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=1.0e03,
+        poissons_ratio=2.5e-01,
+    )
+
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    # Affine displacement field:
+    #   u_x = stretch * x
+    #   u_y = 0
+    _apply_prescribed_bc(step, nodes="YFIX", dofs=[Y], value=0.0)
+
+    _apply_prescribed_bc(step, nodes="X00", dofs=[X], value=0.0)
+    _apply_prescribed_bc(step, nodes="X025", dofs=[X], value=stretch * 0.25)
+    _apply_prescribed_bc(step, nodes="X05", dofs=[X], value=stretch * 0.50)
+    _apply_prescribed_bc(step, nodes="X075", dofs=[X], value=stretch * 0.75)
+    _apply_prescribed_bc(step, nodes="X10", dofs=[X], value=stretch * 1.00)
+
+    simulation.run()
+
+    u = final_nodal_displacements(simulation)
+    x = np.array([x for _, x, _ in nodes], dtype=float)
+    expected_ux = stretch * x
+    expected_uy = np.zeros_like(expected_ux)
+
+    assert np.allclose(u[:, 0], expected_ux, atol=1e-12, rtol=1e-12)
+    assert np.allclose(u[:, 1], expected_uy, atol=1e-12, rtol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "element_factory",
+    [
+        felib.element.CPE8,
+        felib.element.CPE8NL,
+        # If you want plane stress instead, swap to:
+        # felib.element.CPS8,
+        # felib.element.CPS8NL,
+    ],
+)
+def test_patch8(element_factory):
+    run_patch8(element_factory())
+
+
+if __name__ == "__main__":
+    run_patch8(felib.element.CPE8())
+    run_patch8(felib.element.CPE8NL())
+    print("patch8 passed")

--- a/tests/slender_traction.py
+++ b/tests/slender_traction.py
@@ -1,0 +1,253 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+import felib
+
+X, Y = felib.X, felib.Y
+
+
+def build_bar_mesh(nelx=8, nely=2, L=10.0, H=1.0):
+    """
+    Slender rectangular bar:
+        [0, L] x [0, H]
+
+    This is a better geometric-nonlinearity benchmark than the square affine test.
+    """
+    nodes = []
+    nid = 1
+    for j in range(nely + 1):
+        y = H * j / nely
+        for i in range(nelx + 1):
+            x = L * i / nelx
+            nodes.append([nid, x, y])
+            nid += 1
+
+    elements = []
+    right_sides = []
+
+    eid = 1
+    for j in range(nely):
+        for i in range(nelx):
+            n1 = j * (nelx + 1) + i + 1
+            n2 = n1 + 1
+            n4 = n1 + (nelx + 1)
+            n3 = n4 + 1
+            elements.append([eid, n1, n2, n3, n4])
+
+            # In this codebase, side 2 is the right edge, as in your patch test.
+            if i == nelx - 1:
+                right_sides.append([eid, 2])
+
+            eid += 1
+
+    mesh = felib.mesh.Mesh(nodes, elements)
+    mesh.block(name="All", elements=list(range(1, len(elements) + 1)), cell_type=felib.element.Quad4)
+
+    left_nodes = [j * (nelx + 1) + 1 for j in range(nely + 1)]
+    right_nodes = [j * (nelx + 1) + (nelx + 1) for j in range(nely + 1)]
+    bottom_nodes = list(range(1, nelx + 2))
+
+    mesh.nodeset(name="LEFT", nodes=left_nodes)
+    mesh.nodeset(name="RIGHT", nodes=right_nodes)
+    mesh.nodeset(name="BOTTOM", nodes=bottom_nodes)
+    mesh.sideset(name="RIGHT_SIDE", sides=right_sides)
+
+    return mesh, nodes, elements, right_nodes, L
+
+
+def run_case(element_obj, traction_mag, youngs_modulus=1.0e03, poissons_ratio=0.0):
+    mesh, _, _, _, _ = build_bar_mesh()
+
+    model = felib.model.Model(mesh, name=f"bar_{element_obj.__class__.__name__}")
+    material = felib.material.LinearElastic(
+        density=1.0,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    model.assign_properties(block="All", element=element_obj, material=material)
+
+    simulation = felib.simulation.Simulation(model)
+    step = simulation.static_step()
+
+    # Zero constraints to remove rigid-body motion and keep the bar-like response clean.
+    step.boundary(nodes="LEFT", dofs=[X])
+    step.boundary(nodes="BOTTOM", dofs=[Y])
+
+    # Large x-traction on the right side.
+    step.traction(sideset="RIGHT_SIDE", magnitude=traction_mag, direction=[1.0, 0.0])
+
+    simulation.run()
+    return simulation
+
+
+def final_nodal_displacements(simulation):
+    """
+    simulation.ndata.data is a NumPy array populated by scatter_dofs(u).
+    We use the final state.
+    """
+    data = np.asarray(simulation.ndata.data)
+    if data.ndim == 3:
+        return data[-1, :, :2]
+    if data.ndim == 2:
+        return data[:, :2]
+    raise ValueError(f"Unexpected ndata.data shape: {data.shape}")
+
+
+def right_edge_mean_ux(simulation, right_node_ids):
+    u = final_nodal_displacements(simulation)
+    idx = np.array(right_node_ids, dtype=int) - 1
+    return float(u[idx, 0].mean())
+
+def plot_displacement_along_bar(traction=750.0):
+    youngs_modulus = 1.0e03
+    poissons_ratio = 0.0
+
+    mesh, nodes, _, _, L = build_bar_mesh()
+
+    sim_linear = run_case(
+        felib.element.CPE4(),
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    sim_nonlinear = run_case(
+        felib.element.CPE4NL(),
+        traction_mag=traction,
+        youngs_modulus=youngs_modulus,
+        poissons_ratio=poissons_ratio,
+    )
+
+    u_lin = final_nodal_displacements(sim_linear)
+    u_nl = final_nodal_displacements(sim_nonlinear)
+
+    # Extract x-coordinates
+    x = np.array([node[1] for node in nodes])
+
+    # Sort for clean plotting
+    order = np.argsort(x)
+    x_sorted = x[order]
+    ux_lin = u_lin[order, 0]
+    ux_nl = u_nl[order, 0]
+
+    # Analytical curve
+    x_line = np.linspace(0.0, L, 200)
+    lam = np.roots([1, 0, -1, -(2 * traction / youngs_modulus)])
+    lam = lam[np.isreal(lam)].real
+    lam = lam[lam > 0][0]
+    ux_ref = (lam - 1.0) * x_line
+
+    # Plot
+    plt.figure(figsize=(7, 5))
+    plt.plot(x_sorted, ux_lin, "o-", label="CPE4")
+    plt.plot(x_sorted, ux_nl, "s-", label="CPE4NL")
+    plt.plot(x_line, ux_ref, "k--", linewidth=2, label="Analytical")
+
+    plt.xlabel("x-position along bar")
+    plt.ylabel("Horizontal displacement $u_x$")
+    plt.title(f"Displacement along bar (traction = {traction})")
+    plt.grid(True, alpha=0.3)
+    plt.legend()
+    plt.show()
+
+
+def finite_strain_bar_reference(traction, length, youngs_modulus):
+    """
+    1D finite-strain bar reference for a linear elastic material in PK2 form:
+        T = (E/2) * (lambda^3 - lambda)
+
+    Solve for lambda > 0, then:
+        u_right = (lambda - 1) * L
+    """
+    coeffs = [1.0, 0.0, -1.0, -(2.0 * traction / youngs_modulus)]
+    roots = np.roots(coeffs)
+    roots = roots[np.isclose(roots.imag, 0.0)].real
+    roots = roots[roots > 0.0]
+    if roots.size == 0:
+        raise ValueError("No positive real stretch ratio found.")
+    lam = roots[np.argmin(np.abs(roots - 1.0))]
+    return (lam - 1.0) * length
+
+
+def collect_curve(element_obj, traction_levels, youngs_modulus=1.0e03, poissons_ratio=0.0):
+    mesh, _, _, right_nodes, L = build_bar_mesh()
+    results = []
+
+    for tr in traction_levels:
+        sim = run_case(
+            element_obj,
+            traction_mag=float(tr),
+            youngs_modulus=youngs_modulus,
+            poissons_ratio=poissons_ratio,
+        )
+        ur = right_edge_mean_ux(sim, right_nodes)
+        uref = finite_strain_bar_reference(float(tr), L, youngs_modulus)
+        results.append((float(tr), ur, uref))
+
+    return np.array(results, dtype=float)  # columns: traction, numerical ux, reference ux
+
+
+def compare_cases():
+    traction_levels = np.array([0.0, 100.0, 250.0, 500.0, 750.0], dtype=float)
+    youngs_modulus = 1.0e03
+    poissons_ratio = 0.0
+
+    linear = collect_curve(felib.element.CPE4(), traction_levels, youngs_modulus, poissons_ratio)
+    nonlinear = collect_curve(felib.element.CPE4NL(), traction_levels, youngs_modulus, poissons_ratio)
+
+    return traction_levels, linear, nonlinear
+
+
+def test_cpe4nl_is_closer_to_finite_strain_reference():
+    traction_levels, linear, nonlinear = compare_cases()
+
+    # Compare the largest load point, where the geometric nonlinearity matters most.
+    lin_err = abs(linear[-1, 1] - linear[-1, 2])
+    nl_err = abs(nonlinear[-1, 1] - nonlinear[-1, 2])
+
+    print("Largest-load linear error   =", lin_err)
+    print("Largest-load nonlinear error=", nl_err)
+
+    assert nl_err < lin_err
+
+
+def main():
+    traction_levels, linear, nonlinear = compare_cases()
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5), constrained_layout=True)
+
+    # Load-displacement comparison
+    axes[0].plot(linear[:, 0], linear[:, 1], "o-", label="CPE4 numerical")
+    axes[0].plot(nonlinear[:, 0], nonlinear[:, 1], "s-", label="CPE4NL numerical")
+    axes[0].plot(linear[:, 0], linear[:, 2], "k--", linewidth=2.0, label="Finite-strain bar reference")
+    axes[0].set_xlabel("Applied traction")
+    axes[0].set_ylabel("Mean right-edge $u_x$")
+    axes[0].set_title("Load-displacement comparison")
+    axes[0].grid(True, alpha=0.3)
+    axes[0].legend()
+
+    # Absolute error comparison
+    lin_err = np.abs(linear[:, 1] - linear[:, 2])
+    nl_err = np.abs(nonlinear[:, 1] - nonlinear[:, 2])
+
+    axes[1].plot(traction_levels, lin_err, "o-", label="CPE4 error")
+    axes[1].plot(traction_levels, nl_err, "s-", label="CPE4NL error")
+    axes[1].set_xlabel("Applied traction")
+    axes[1].set_ylabel("Absolute error in $u_x$")
+    axes[1].set_title("Error vs finite-strain reference")
+    axes[1].grid(True, alpha=0.3)
+    axes[1].legend()
+
+    plt.show()
+
+    print("\nTraction   CPE4 ux   CPE4NL ux   Reference ux")
+    for tr, (t1, u1, r1), (_, u2, r2) in zip(traction_levels, linear, nonlinear):
+        print(f"{tr:8.1f}  {u1:8.4f}  {u2:9.4f}  {r1:11.4f}")
+
+
+if __name__ == "__main__":
+    main()
+
+if __name__ == "__main__":
+    plot_displacement_along_bar(traction=750.0)


### PR DESCRIPTION
@rachelcorinneharris - I fixed conflicts and some linting/formatting errors.  I also re-arranged the nlgeom element definitions to avoid some type checking errors.  I was unable to push to your fork, so I opened this new PR.  Feel free to work from this branch.

## Summary by Sourcery

Add geometrically nonlinear continuum element support and corresponding verification tests.

New Features:
- Introduce NLGeom mixin providing 2D large‑strain kinematics, Green–Lagrange strain handling, and Piola-based consistent tangent for continuum elements.
- Add nonlinear geometric variants of existing plane-strain and plane-stress elements (CPE3NL, CPE4NL, CPE8NL, CPS3NL, CPS4NL, CPS8NL) and export them from the element package.

Enhancements:
- Extend IsoparametricElement with configuration flags for local pressure usage and pressure DOF count.
- Standardize naming of the displacement-to-nodal matrix in element integration code for clarity.

Tests:
- Switch the existing patch4 test to the nonlinear CPE4NL element with a tolerance suitable for large-strain behavior.
- Add multiple cantilever and slender-bar convergence and comparison tests to validate small- and large-strain responses of linear vs nonlinear elements.
- Add block, patch3, and patch8 patch tests to verify affine deformation fields for triangular and quadratic quadrilateral elements under nonlinear kinematics.